### PR TITLE
Fix default values for v1 pipeline

### DIFF
--- a/kfp_toolbox/pipelines.py
+++ b/kfp_toolbox/pipelines.py
@@ -33,9 +33,9 @@ def _type_function_from_name(type_name: str) -> Callable:
 
 
 def _actual_parameter_value(key: str, value: ParameterValue) -> ParameterValue:
-    if key == "intValue":
+    if key in {"Integer", "intValue"}:
         actual_value = int(value)
-    elif key == "doubleValue":
+    elif key in {"Float", "doubleValue"}:
         actual_value = float(value)
     else:
         actual_value = str(value)
@@ -74,13 +74,13 @@ def _create_v1_pipeline(pipeline_spec: Mapping[str, Any]) -> Pipeline:
 
     parameters = []
     for item in spec_json["inputs"]:
-        parameter_name = item["name"]
-        if parameter_name in {"pipeline-root", "pipeline-name"}:
+        if item["name"] in {"pipeline-root", "pipeline-name"}:
             continue
-        parameter_type = _type_function_from_name(item["type"])
-        parameter = Parameter(name=parameter_name, type=parameter_type)
-        if item.get("default"):
-            parameter.default = parameter_type(item["default"])
+        parameter = Parameter(
+            name=item["name"], type=_type_function_from_name(item["type"])
+        )
+        if item.get("default") is not None:
+            parameter.default = _actual_parameter_value(item["type"], item["default"])
         parameters.append(parameter)
 
     return Pipeline(name=pipeline_name, parameters=parameters)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -91,6 +91,64 @@ def test_load_pipeline_from_file(tmp_path):
     assert dict_param in pipeline.parameters
 
 
+def test_load_pipeline_from_file_v1_with_falsy_default_values(tmp_path):
+    @dsl.component
+    def echo() -> str:
+        return "hello, world"
+
+    @dsl.pipeline(name="echo-pipeline")
+    def echo_pipeline(
+        int_param: int = 0,
+        float_param: float = 0.0,
+        str_param: str = "",
+    ):
+        echo()
+
+    pipeline_path = os.fspath(tmp_path / "pipeline.yaml")
+    compiler_v1.Compiler(mode=PipelineExecutionMode.V2_COMPATIBLE).compile(
+        pipeline_func=echo_pipeline, package_path=pipeline_path
+    )
+    pipeline = load_pipeline_from_file(pipeline_path)
+
+    int_param = Parameter(name="int_param", type=int, default=0)
+    float_param = Parameter(name="float_param", type=float, default=0.0)
+    str_param = Parameter(name="str_param", type=str, default="")
+
+    assert pipeline.name == "echo-pipeline"
+    assert len(pipeline.parameters) == 3
+    assert int_param in pipeline.parameters
+    assert float_param in pipeline.parameters
+    assert str_param in pipeline.parameters
+
+
+def test_load_pipeline_from_file_with_falsy_default_values(tmp_path):
+    @dsl.component
+    def echo() -> str:
+        return "hello, world"
+
+    @dsl.pipeline(name="echo-pipeline")
+    def echo_pipeline(
+        int_param: int = 0,
+        float_param: float = 0.0,
+        str_param: str = "",
+    ):
+        echo()
+
+    pipeline_path = os.fspath(tmp_path / "pipeline.json")
+    compiler.Compiler().compile(pipeline_func=echo_pipeline, package_path=pipeline_path)
+    pipeline = load_pipeline_from_file(pipeline_path)
+
+    int_param = Parameter(name="int_param", type=int, default=0)
+    float_param = Parameter(name="float_param", type=float, default=0.0)
+    str_param = Parameter(name="str_param", type=str, default="")
+
+    assert pipeline.name == "echo-pipeline"
+    assert len(pipeline.parameters) == 3
+    assert int_param in pipeline.parameters
+    assert float_param in pipeline.parameters
+    assert str_param in pipeline.parameters
+
+
 def test_load_pipeline_from_file_with_no_parameters_v1(tmp_path):
     @dsl.component
     def echo() -> str:

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -149,7 +149,7 @@ def test_load_pipeline_from_file_with_falsy_default_values(tmp_path):
     assert str_param in pipeline.parameters
 
 
-def test_load_pipeline_from_file_with_no_parameters_v1(tmp_path):
+def test_load_pipeline_from_file_v1_with_no_parameters(tmp_path):
     @dsl.component
     def echo() -> str:
         return "hello, world"


### PR DESCRIPTION
Fixed a problem in which the default value of a parameter in the v1 pipeline was not set correctly if it was an empty string.