### PR TITLE
Enable caching on setup-python

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,22 +14,14 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
-      id: setup-python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: snok/install-poetry@v1
+        cache: 'poetry'
 
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v3
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-    - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction --no-root
     - name: Install library
       run: poetry install --no-interaction
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,7 +23,9 @@ jobs:
           cache: "poetry"
 
       - name: Install library
-        run: poetry install --no-interaction
+        run: |
+          poetry env use ${{ matrix.python-version }}
+          poetry install --no-interaction
 
       - name: Test with pytest
         run: poetry run pytest -v ./tests

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ name: Python Tests
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Install poetry
-      run: pipx install poetry
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'poetry'
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
 
-    - name: Install library
-      run: poetry install --no-interaction
+      - name: Install library
+        run: poetry install --no-interaction
 
-    - name: Test with pytest
-      run: poetry run pytest -v ./tests
+      - name: Test with pytest
+        run: poetry run pytest -v ./tests
 
-    - name: Upload coverage reports
-      uses: codecov/codecov-action@v2
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -8,18 +8,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install poetry
-      run: pipx install poetry
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
+      - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
 
-    - name: Build
-      run: poetry build
+      - name: Build
+        run: poetry build
 
-    - name: Publish
-      run: |
-        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-        poetry publish
+      - name: Publish
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry publish

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -9,8 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: snok/install-poetry@v1
+    - name: Install poetry
+      run: pipx install poetry
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
 
     - name: Build
       run: poetry build

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -11,10 +11,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
 
       - name: Build
         run: poetry build


### PR DESCRIPTION
Use pipx to install poetry. pipx is available in the github actions
environment.

Since setup-python can handle cache, it is no longer necessary to use
actions/cache.