### PR TITLE
Introduce Make as a task runner

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,9 +24,7 @@ jobs:
           poetry install --no-interaction
 
       - name: Build
-        run: |
-          poetry run sphinx-apidoc --no-toc --output-dir=./docs/api ./src
-          poetry run sphinx-build -W -b html ./docs ./docs/_build/html
+        run: poetry run make html
 
       - name: Publish
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,7 +28,7 @@ jobs:
           poetry install --no-interaction
 
       - name: Test with pytest
-        run: poetry run pytest -v ./tests
+        run: poetry run make test
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,7 +27,7 @@ jobs:
           poetry env use ${{ steps.setup-python.outputs.python-version }}
           poetry install --no-interaction
 
-      - name: Test with pytest
+      - name: Test
         run: poetry run make test
 
       - name: Upload coverage reports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all clean build lint test html livehtml
+
+all: build html
+
+clean:
+	rm -rf ./dist ./docs/_build ./docs/api/*.rst
+
+build: lint test
+	poetry build
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest -v ./tests
+
+html:
+	sphinx-apidoc --no-toc --force --output-dir=./docs/api ./src
+	sphinx-build -W -b html ./docs ./docs/_build/html
+
+livehtml: html
+	sphinx-autobuild -b html ./docs ./docs/_build/html


### PR DESCRIPTION
When building a package with GitHub Actions, run poetry directly
instead of make. Because it does not install lint and test dependency
libraries.