### PR TITLE
Use Vertex AI Experiments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "kfp~=1.8",
-    "google-cloud-aiplatform~=1.7",
+    "google-cloud-aiplatform~=1.15",
     "typer>=0.4, <1.0",
     "pyyaml>=5.3",
     "importlib-metadata>=1.4; python_version < '3.8'",

--- a/src/kfp_toolbox/pipelines.py
+++ b/src/kfp_toolbox/pipelines.py
@@ -245,10 +245,6 @@ def submit_pipeline_job(
     else:  # Vertex AI Pipelines
         from google.cloud import aiplatform
 
-        new_labels = dict(labels) if labels else {}
-        if experiment_name:
-            new_labels = {"experiment": experiment_name}
-
         job = aiplatform.PipelineJob(
             display_name=None,  # type: ignore  # will be generated
             template_path=pipeline_file_str,
@@ -257,8 +253,10 @@ def submit_pipeline_job(
             parameter_values=arguments,  # type: ignore
             enable_caching=enable_caching,
             encryption_spec_key_name=encryption_spec_key_name,
-            labels=new_labels,
+            labels=labels,  # type: ignore
             project=project,
             location=location,
         )
-        job.submit(service_account=service_account, network=network)
+        job.submit(
+            service_account=service_account, network=network, experiment=experiment_name
+        )

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -237,12 +237,12 @@ def test_submit_pipeline_job(mock_kfp, mock_aip):
         parameter_values={"param": 1},
         enable_caching=None,
         encryption_spec_key_name=None,
-        labels={"experiment": "test-experiment"},
+        labels=None,
         project=None,
         location=None,
     )
     mock_aip.return_value.submit.assert_called_once_with(
-        service_account=None, network=None
+        service_account=None, network=None, experiment="test-experiment"
     )
 
 


### PR DESCRIPTION
Labels was used to handle experiment_name in Vertex AI Pipelines, but
it should correctly correspond to Vertex AI Experiments.

Vertex AI Experiments requires version 1.15 or higher of
google-cloud-aiplatform.
https://github.com/googleapis/python-aiplatform/blob/v1.15.0/CHANGELOG.md#1150-2022-06-29