### PR TITLE
Use setup-python when building packages

### DIFF
--- a/.github/workflows/publish-python-package.yml
+++ b/.github/workflows/publish-python-package.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install "$(ls ./dist/*-py3-none-any.whl)[test]"
+          python3 -m pip install "$(ls ./dist/*-py3-none-any.whl | tail -1)[test]"
 
       - name: Test
         run: make test


### PR DESCRIPTION
This is because the default python environment has several packages
installed, which may cause version conflicts.