### PR TITLE
Manage dependent packages with requirements.txt

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Install dependencies
         run: python3 -m pip install ".[docs]"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Build
         run: make build
@@ -41,7 +40,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
 
 [project]
@@ -12,6 +12,7 @@ authors = [
 readme = "README.md"
 license = "MIT"
 
+requires-python = ">=3.7"
 keywords = ["kfp", "kubeflow", "pipelines"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -26,16 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-dynamic = ["version"]
-
-requires-python = ">=3.7"
-dependencies = [
-    "kfp~=1.8",
-    "google-cloud-aiplatform~=1.15",
-    "typer>=0.4, <1.0",
-    "pyyaml>=5.3",
-    "importlib-metadata>=1.4; python_version < '3.8'",
-]
+dynamic = ["version", "dependencies"]
 
 [project.optional-dependencies]
 test = [
@@ -61,6 +53,9 @@ source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/kfp_toolbox/versions.py"
+
+[tool.hatch.metadata.hooks.requirements_txt]
+filename = "requirements.txt"
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+kfp~=1.8
+google-cloud-aiplatform~=1.15
+typer>=0.4, <1.0
+pyyaml>=5.3


### PR DESCRIPTION
Because dependency packages managed in pyproject.toml are not displayed in the dependency graph on GitHub.