### PR TITLE
Install wheel for packages that are doing a legacy install

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,7 +19,9 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: python3 -m pip install ".[docs]"
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install ".[docs]"
 
       - name: Build
         run: make html

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,9 @@ jobs:
           path: ./dist
 
       - name: Install dependencies
-        run: python3 -m pip install "$(ls ./dist/*-py3-none-any.whl | tail -1)[test]"
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install "$(ls ./dist/*-py3-none-any.whl | tail -1)[test]"
 
       - name: Test
         run: make test


### PR DESCRIPTION
```
Using legacy 'setup.py install' for kfp, since package 'wheel' is not installed.
Using legacy 'setup.py install' for fire, since package 'wheel' is not installed.
Using legacy 'setup.py install' for kfp-server-api, since package 'wheel' is not installed.
Using legacy 'setup.py install' for strip-hints, since package 'wheel' is not installed.
Using legacy 'setup.py install' for livereload, since package 'wheel' is not installed.
```