### PR TITLE
Add override_docstring decorator

### DIFF
--- a/src/kfp_toolbox/__init__.py
+++ b/src/kfp_toolbox/__init__.py
@@ -1,4 +1,4 @@
-from .decorators import spec  # noqa: F401
+from .decorators import override_docstring, spec  # noqa: F401
 
 # "versions.py" is automatically generated when building a package.
 from .versions import __version__  # noqa: F401

--- a/src/kfp_toolbox/components.py
+++ b/src/kfp_toolbox/components.py
@@ -2,10 +2,11 @@ from typing import Optional
 
 from kfp.v2 import dsl
 
-from .decorators import spec
+from .decorators import override_docstring, spec
 
 
 @spec(caching=False)
+@override_docstring()
 @dsl.component()
 def timestamp(
     format: str = "%Y%m%d%H%M%S",

--- a/src/kfp_toolbox/decorators.py
+++ b/src/kfp_toolbox/decorators.py
@@ -2,6 +2,28 @@ import functools
 from typing import Optional
 
 
+def override_docstring(docs: Optional[str] = None):
+    """Override the docstring of the component.
+
+    Args:
+        docs (Optional[str], optional): The docstring to be overwritten. If None, the
+            docstring of the original function is adopted. Defaults to None.
+
+    Returns:
+        Callable: A decorator function with the specified docstring.
+
+    """
+
+    def _decorator(func):
+        if docs is not None:
+            func.__doc__ = docs
+        elif hasattr(func, "python_func") and func.python_func.__doc__:
+            func.__doc__ = func.python_func.__doc__
+        return func
+
+    return _decorator
+
+
 def spec(
     name: Optional[str] = None,
     cpu: Optional[str] = None,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,7 +5,7 @@ from kfp import compiler as compiler_v1
 from kfp import dsl as dsl_v1
 from kfp.v2 import compiler, dsl
 
-from kfp_toolbox import spec
+from kfp_toolbox import override_docstring, spec
 
 
 def test_spec_v1_as_decorator(tmp_path):
@@ -254,3 +254,53 @@ def test_spec_with_multiple_decorators(tmp_path):
 
     assert container["resources"]["cpuLimit"] == 1.0
     assert container["resources"]["memoryLimit"] == 16.0
+
+
+def test_override_docstring_no_decorators():
+    @dsl.component()
+    def echo() -> str:
+        """Say hello
+
+        This component just says hello.
+
+        Returns:
+            str: hello
+        """
+        return "hello, world"
+
+    assert echo.__doc__ == "Echo\nSay hello"
+
+
+def test_override_docstring():
+    @override_docstring()
+    @dsl.component()
+    def echo() -> str:
+        """Say hello
+
+        This component just says hello.
+
+        Returns:
+            str: hello
+        """
+        return "hello, world"
+
+    assert echo.__doc__ == (
+        "Say hello\n\n        This component just says hello.\n\n"
+        "        Returns:\n            str: hello\n        "
+    )
+
+
+def test_override_docstring_specific_docs():
+    @override_docstring("Just say hello component")
+    @dsl.component()
+    def echo() -> str:
+        """Say hello
+
+        This component just says hello.
+
+        Returns:
+            str: hello
+        """
+        return "hello, world"
+
+    assert echo.__doc__ == "Just say hello component"


### PR DESCRIPTION
The docstring set in the component of the python function is only the component name and short_description.

By using the override_docstring decorator, the docstring set in the original python function can be adopted. Additionally, individual docstrings can be set directly to the decorator.