### PR TITLE
Reduce the frequency of pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,6 @@ repos:
     rev: v0.0.249
     hooks:
       - id: ruff
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Quarterly updates are sufficient since there are few significant pre-commit updates.

https://pre-commit.ci/#configuration